### PR TITLE
Vite libraries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Build
+        run: pnpm build
+
       - name: Run ESLint
         run: pnpm lint
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/examples/package.json
+++ b/examples/package.json
@@ -21,7 +21,6 @@
   "devDependencies": {
     "@types/three": "^0.149.0",
     "typescript": "~5.0.4",
-    "vite": "^4.3.4",
-    "vite-plugin-wasm": "^3.2.2"
+    "vite": "^4.3.4"
   }
 }

--- a/examples/package.json
+++ b/examples/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "tsc && vite build",
     "dev": "vite",
-    "serve": "vite preview"
+    "preview": "vite preview"
   },
   "dependencies": {
     "@lattice-engine/core": "workspace:^",

--- a/examples/public/FlightHelmet/FlightHelmet.gltf
+++ b/examples/public/FlightHelmet/FlightHelmet.gltf
@@ -1,705 +1,650 @@
 {
-    "asset": {
-        "version": "2.0",
-        "generator": "babylon.js glTF exporter for Maya 2018 v20200228.3 (with minor hand modifications)"
+  "asset": {
+    "version": "2.0",
+    "generator": "babylon.js glTF exporter for Maya 2018 v20200228.3 (with minor hand modifications)"
+  },
+  "scene": 0,
+  "scenes": [
+    {
+      "nodes": [0, 1, 2, 3, 4, 5]
+    }
+  ],
+  "nodes": [
+    {
+      "mesh": 0,
+      "name": "Hose_low"
     },
-    "scene": 0,
-    "scenes": [
+    {
+      "mesh": 1,
+      "name": "RubberWood_low"
+    },
+    {
+      "mesh": 2,
+      "name": "GlassPlastic_low"
+    },
+    {
+      "mesh": 3,
+      "name": "MetalParts_low"
+    },
+    {
+      "mesh": 4,
+      "name": "LeatherParts_low"
+    },
+    {
+      "mesh": 5,
+      "name": "Lenses_low"
+    }
+  ],
+  "meshes": [
+    {
+      "primitives": [
         {
-            "nodes": [
-                0,
-                1,
-                2,
-                3,
-                4,
-                5
-            ]
+          "attributes": {
+            "POSITION": 1,
+            "TANGENT": 2,
+            "NORMAL": 3,
+            "TEXCOORD_0": 4
+          },
+          "indices": 0,
+          "material": 0
         }
-    ],
-    "nodes": [
+      ],
+      "name": "Hose_low"
+    },
+    {
+      "primitives": [
         {
-            "mesh": 0,
-            "name": "Hose_low"
-        },
-        {
-            "mesh": 1,
-            "name": "RubberWood_low"
-        },
-        {
-            "mesh": 2,
-            "name": "GlassPlastic_low"
-        },
-        {
-            "mesh": 3,
-            "name": "MetalParts_low"
-        },
-        {
-            "mesh": 4,
-            "name": "LeatherParts_low"
-        },
-        {
-            "mesh": 5,
-            "name": "Lenses_low"
+          "attributes": {
+            "POSITION": 6,
+            "TANGENT": 7,
+            "NORMAL": 8,
+            "TEXCOORD_0": 9
+          },
+          "indices": 5,
+          "material": 1
         }
-    ],
-    "meshes": [
+      ],
+      "name": "RubberWood_low"
+    },
+    {
+      "primitives": [
         {
-            "primitives": [
-                {
-                    "attributes": {
-                        "POSITION": 1,
-                        "TANGENT": 2,
-                        "NORMAL": 3,
-                        "TEXCOORD_0": 4
-                    },
-                    "indices": 0,
-                    "material": 0
-                }
-            ],
-            "name": "Hose_low"
-        },
-        {
-            "primitives": [
-                {
-                    "attributes": {
-                        "POSITION": 6,
-                        "TANGENT": 7,
-                        "NORMAL": 8,
-                        "TEXCOORD_0": 9
-                    },
-                    "indices": 5,
-                    "material": 1
-                }
-            ],
-            "name": "RubberWood_low"
-        },
-        {
-            "primitives": [
-                {
-                    "attributes": {
-                        "POSITION": 11,
-                        "TANGENT": 12,
-                        "NORMAL": 13,
-                        "TEXCOORD_0": 14
-                    },
-                    "indices": 10,
-                    "material": 2
-                }
-            ],
-            "name": "GlassPlastic_low"
-        },
-        {
-            "primitives": [
-                {
-                    "attributes": {
-                        "POSITION": 16,
-                        "TANGENT": 17,
-                        "NORMAL": 18,
-                        "TEXCOORD_0": 19
-                    },
-                    "indices": 15,
-                    "material": 3
-                }
-            ],
-            "name": "MetalParts_low"
-        },
-        {
-            "primitives": [
-                {
-                    "attributes": {
-                        "POSITION": 21,
-                        "TANGENT": 22,
-                        "NORMAL": 23,
-                        "TEXCOORD_0": 24
-                    },
-                    "indices": 20,
-                    "material": 4
-                }
-            ],
-            "name": "LeatherParts_low"
-        },
-        {
-            "primitives": [
-                {
-                    "attributes": {
-                        "POSITION": 26,
-                        "TANGENT": 27,
-                        "NORMAL": 28,
-                        "TEXCOORD_0": 29
-                    },
-                    "indices": 25,
-                    "material": 5
-                }
-            ],
-            "name": "Lenses_low"
+          "attributes": {
+            "POSITION": 11,
+            "TANGENT": 12,
+            "NORMAL": 13,
+            "TEXCOORD_0": 14
+          },
+          "indices": 10,
+          "material": 2
         }
-    ],
-    "accessors": [
+      ],
+      "name": "GlassPlastic_low"
+    },
+    {
+      "primitives": [
         {
-            "bufferView": 0,
-            "componentType": 5123,
-            "count": 59040,
-            "type": "SCALAR",
-            "name": "accessorIndices"
-        },
-        {
-            "bufferView": 1,
-            "componentType": 5126,
-            "count": 10472,
-            "max": [
-                0.10810829,
-                0.356580257,
-                0.190409869
-            ],
-            "min": [
-                -0.07221258,
-                0.104120225,
-                -0.088394776
-            ],
-            "type": "VEC3",
-            "name": "accessorPositions"
-        },
-        {
-            "bufferView": 2,
-            "componentType": 5126,
-            "count": 10472,
-            "type": "VEC4",
-            "name": "accessorTangents"
-        },
-        {
-            "bufferView": 1,
-            "byteOffset": 125664,
-            "componentType": 5126,
-            "count": 10472,
-            "type": "VEC3",
-            "name": "accessorNormals"
-        },
-        {
-            "bufferView": 3,
-            "componentType": 5126,
-            "count": 10472,
-            "type": "VEC2",
-            "name": "accessorUVs"
-        },
-        {
-            "bufferView": 0,
-            "byteOffset": 118080,
-            "componentType": 5123,
-            "count": 72534,
-            "type": "SCALAR",
-            "name": "accessorIndices"
-        },
-        {
-            "bufferView": 1,
-            "byteOffset": 251328,
-            "componentType": 5126,
-            "count": 13638,
-            "max": [
-                0.162940636,
-                0.7025226,
-                0.200029165
-            ],
-            "min": [
-                -0.158857465,
-                -2.14242937E-05,
-                -0.171545789
-            ],
-            "type": "VEC3",
-            "name": "accessorPositions"
-        },
-        {
-            "bufferView": 2,
-            "byteOffset": 167552,
-            "componentType": 5126,
-            "count": 13638,
-            "type": "VEC4",
-            "name": "accessorTangents"
-        },
-        {
-            "bufferView": 1,
-            "byteOffset": 414984,
-            "componentType": 5126,
-            "count": 13638,
-            "type": "VEC3",
-            "name": "accessorNormals"
-        },
-        {
-            "bufferView": 3,
-            "byteOffset": 83776,
-            "componentType": 5126,
-            "count": 13638,
-            "type": "VEC2",
-            "name": "accessorUVs"
-        },
-        {
-            "bufferView": 0,
-            "byteOffset": 263148,
-            "componentType": 5123,
-            "count": 24408,
-            "type": "SCALAR",
-            "name": "accessorIndices"
-        },
-        {
-            "bufferView": 1,
-            "byteOffset": 578640,
-            "componentType": 5126,
-            "count": 4676,
-            "max": [
-                0.140494063,
-                0.61828655,
-                0.147373646
-            ],
-            "min": [
-                -0.140846014,
-                0.440957,
-                -0.107818365
-            ],
-            "type": "VEC3",
-            "name": "accessorPositions"
-        },
-        {
-            "bufferView": 2,
-            "byteOffset": 385760,
-            "componentType": 5126,
-            "count": 4676,
-            "type": "VEC4",
-            "name": "accessorTangents"
-        },
-        {
-            "bufferView": 1,
-            "byteOffset": 634752,
-            "componentType": 5126,
-            "count": 4676,
-            "type": "VEC3",
-            "name": "accessorNormals"
-        },
-        {
-            "bufferView": 3,
-            "byteOffset": 192880,
-            "componentType": 5126,
-            "count": 4676,
-            "type": "VEC2",
-            "name": "accessorUVs"
-        },
-        {
-            "bufferView": 0,
-            "byteOffset": 311964,
-            "componentType": 5123,
-            "count": 60288,
-            "type": "SCALAR",
-            "name": "accessorIndices"
-        },
-        {
-            "bufferView": 1,
-            "byteOffset": 690864,
-            "componentType": 5126,
-            "count": 13636,
-            "max": [
-                0.132708371,
-                0.6024364,
-                0.199477077
-            ],
-            "min": [
-                -0.203642711,
-                0.02116075,
-                -0.147512689
-            ],
-            "type": "VEC3",
-            "name": "accessorPositions"
-        },
-        {
-            "bufferView": 2,
-            "byteOffset": 460576,
-            "componentType": 5126,
-            "count": 13636,
-            "type": "VEC4",
-            "name": "accessorTangents"
-        },
-        {
-            "bufferView": 1,
-            "byteOffset": 854496,
-            "componentType": 5126,
-            "count": 13636,
-            "type": "VEC3",
-            "name": "accessorNormals"
-        },
-        {
-            "bufferView": 3,
-            "byteOffset": 230288,
-            "componentType": 5126,
-            "count": 13636,
-            "type": "VEC2",
-            "name": "accessorUVs"
-        },
-        {
-            "bufferView": 0,
-            "byteOffset": 432540,
-            "componentType": 5123,
-            "count": 65688,
-            "type": "SCALAR",
-            "name": "accessorIndices"
-        },
-        {
-            "bufferView": 1,
-            "byteOffset": 1018128,
-            "componentType": 5126,
-            "count": 12534,
-            "max": [
-                0.124933377,
-                0.716000438,
-                0.129168555
-            ],
-            "min": [
-                -0.125863016,
-                0.2958266,
-                -0.1541516
-            ],
-            "type": "VEC3",
-            "name": "accessorPositions"
-        },
-        {
-            "bufferView": 2,
-            "byteOffset": 678752,
-            "componentType": 5126,
-            "count": 12534,
-            "type": "VEC4",
-            "name": "accessorTangents"
-        },
-        {
-            "bufferView": 1,
-            "byteOffset": 1168536,
-            "componentType": 5126,
-            "count": 12534,
-            "type": "VEC3",
-            "name": "accessorNormals"
-        },
-        {
-            "bufferView": 3,
-            "byteOffset": 339376,
-            "componentType": 5126,
-            "count": 12534,
-            "type": "VEC2",
-            "name": "accessorUVs"
-        },
-        {
-            "bufferView": 0,
-            "byteOffset": 563916,
-            "componentType": 5123,
-            "count": 2208,
-            "type": "SCALAR",
-            "name": "accessorIndices"
-        },
-        {
-            "bufferView": 1,
-            "byteOffset": 1318944,
-            "componentType": 5126,
-            "count": 436,
-            "max": [
-                0.101920746,
-                0.5936986,
-                0.152926728
-            ],
-            "min": [
-                -0.101920947,
-                0.5300429,
-                0.090174824
-            ],
-            "type": "VEC3",
-            "name": "accessorPositions"
-        },
-        {
-            "bufferView": 2,
-            "byteOffset": 879296,
-            "componentType": 5126,
-            "count": 436,
-            "type": "VEC4",
-            "name": "accessorTangents"
-        },
-        {
-            "bufferView": 1,
-            "byteOffset": 1324176,
-            "componentType": 5126,
-            "count": 436,
-            "type": "VEC3",
-            "name": "accessorNormals"
-        },
-        {
-            "bufferView": 3,
-            "byteOffset": 439648,
-            "componentType": 5126,
-            "count": 436,
-            "type": "VEC2",
-            "name": "accessorUVs"
+          "attributes": {
+            "POSITION": 16,
+            "TANGENT": 17,
+            "NORMAL": 18,
+            "TEXCOORD_0": 19
+          },
+          "indices": 15,
+          "material": 3
         }
-    ],
-    "bufferViews": [
+      ],
+      "name": "MetalParts_low"
+    },
+    {
+      "primitives": [
         {
-            "buffer": 0,
-            "byteLength": 568332,
-            "name": "bufferViewScalar"
-        },
-        {
-            "buffer": 0,
-            "byteOffset": 568332,
-            "byteLength": 1329408,
-            "byteStride": 12,
-            "name": "bufferViewFloatVec3"
-        },
-        {
-            "buffer": 0,
-            "byteOffset": 1897740,
-            "byteLength": 886272,
-            "byteStride": 16,
-            "name": "bufferViewFloatVec4"
-        },
-        {
-            "buffer": 0,
-            "byteOffset": 2784012,
-            "byteLength": 443136,
-            "byteStride": 8,
-            "name": "bufferViewFloatVec2"
+          "attributes": {
+            "POSITION": 21,
+            "TANGENT": 22,
+            "NORMAL": 23,
+            "TEXCOORD_0": 24
+          },
+          "indices": 20,
+          "material": 4
         }
-    ],
-    "buffers": [
+      ],
+      "name": "LeatherParts_low"
+    },
+    {
+      "primitives": [
         {
-            "uri": "FlightHelmet.bin",
-            "byteLength": 3227148
+          "attributes": {
+            "POSITION": 26,
+            "TANGENT": 27,
+            "NORMAL": 28,
+            "TEXCOORD_0": 29
+          },
+          "indices": 25,
+          "material": 5
         }
-    ],
-    "materials": [
-        {
-            "pbrMetallicRoughness": {
-                "baseColorTexture": {
-                    "index": 2
-                },
-                "metallicRoughnessTexture": {
-                    "index": 1
-                }
-            },
-            "normalTexture": {
-                "index": 0
-            },
-            "occlusionTexture": {
-                "index": 1
-            },
-            "doubleSided": true,
-            "name": "HoseMat"
+      ],
+      "name": "Lenses_low"
+    }
+  ],
+  "accessors": [
+    {
+      "bufferView": 0,
+      "componentType": 5123,
+      "count": 59040,
+      "type": "SCALAR",
+      "name": "accessorIndices"
+    },
+    {
+      "bufferView": 1,
+      "componentType": 5126,
+      "count": 10472,
+      "max": [0.10810829, 0.356580257, 0.190409869],
+      "min": [-0.07221258, 0.104120225, -0.088394776],
+      "type": "VEC3",
+      "name": "accessorPositions"
+    },
+    {
+      "bufferView": 2,
+      "componentType": 5126,
+      "count": 10472,
+      "type": "VEC4",
+      "name": "accessorTangents"
+    },
+    {
+      "bufferView": 1,
+      "byteOffset": 125664,
+      "componentType": 5126,
+      "count": 10472,
+      "type": "VEC3",
+      "name": "accessorNormals"
+    },
+    {
+      "bufferView": 3,
+      "componentType": 5126,
+      "count": 10472,
+      "type": "VEC2",
+      "name": "accessorUVs"
+    },
+    {
+      "bufferView": 0,
+      "byteOffset": 118080,
+      "componentType": 5123,
+      "count": 72534,
+      "type": "SCALAR",
+      "name": "accessorIndices"
+    },
+    {
+      "bufferView": 1,
+      "byteOffset": 251328,
+      "componentType": 5126,
+      "count": 13638,
+      "max": [0.162940636, 0.7025226, 0.200029165],
+      "min": [-0.158857465, -2.14242937e-5, -0.171545789],
+      "type": "VEC3",
+      "name": "accessorPositions"
+    },
+    {
+      "bufferView": 2,
+      "byteOffset": 167552,
+      "componentType": 5126,
+      "count": 13638,
+      "type": "VEC4",
+      "name": "accessorTangents"
+    },
+    {
+      "bufferView": 1,
+      "byteOffset": 414984,
+      "componentType": 5126,
+      "count": 13638,
+      "type": "VEC3",
+      "name": "accessorNormals"
+    },
+    {
+      "bufferView": 3,
+      "byteOffset": 83776,
+      "componentType": 5126,
+      "count": 13638,
+      "type": "VEC2",
+      "name": "accessorUVs"
+    },
+    {
+      "bufferView": 0,
+      "byteOffset": 263148,
+      "componentType": 5123,
+      "count": 24408,
+      "type": "SCALAR",
+      "name": "accessorIndices"
+    },
+    {
+      "bufferView": 1,
+      "byteOffset": 578640,
+      "componentType": 5126,
+      "count": 4676,
+      "max": [0.140494063, 0.61828655, 0.147373646],
+      "min": [-0.140846014, 0.440957, -0.107818365],
+      "type": "VEC3",
+      "name": "accessorPositions"
+    },
+    {
+      "bufferView": 2,
+      "byteOffset": 385760,
+      "componentType": 5126,
+      "count": 4676,
+      "type": "VEC4",
+      "name": "accessorTangents"
+    },
+    {
+      "bufferView": 1,
+      "byteOffset": 634752,
+      "componentType": 5126,
+      "count": 4676,
+      "type": "VEC3",
+      "name": "accessorNormals"
+    },
+    {
+      "bufferView": 3,
+      "byteOffset": 192880,
+      "componentType": 5126,
+      "count": 4676,
+      "type": "VEC2",
+      "name": "accessorUVs"
+    },
+    {
+      "bufferView": 0,
+      "byteOffset": 311964,
+      "componentType": 5123,
+      "count": 60288,
+      "type": "SCALAR",
+      "name": "accessorIndices"
+    },
+    {
+      "bufferView": 1,
+      "byteOffset": 690864,
+      "componentType": 5126,
+      "count": 13636,
+      "max": [0.132708371, 0.6024364, 0.199477077],
+      "min": [-0.203642711, 0.02116075, -0.147512689],
+      "type": "VEC3",
+      "name": "accessorPositions"
+    },
+    {
+      "bufferView": 2,
+      "byteOffset": 460576,
+      "componentType": 5126,
+      "count": 13636,
+      "type": "VEC4",
+      "name": "accessorTangents"
+    },
+    {
+      "bufferView": 1,
+      "byteOffset": 854496,
+      "componentType": 5126,
+      "count": 13636,
+      "type": "VEC3",
+      "name": "accessorNormals"
+    },
+    {
+      "bufferView": 3,
+      "byteOffset": 230288,
+      "componentType": 5126,
+      "count": 13636,
+      "type": "VEC2",
+      "name": "accessorUVs"
+    },
+    {
+      "bufferView": 0,
+      "byteOffset": 432540,
+      "componentType": 5123,
+      "count": 65688,
+      "type": "SCALAR",
+      "name": "accessorIndices"
+    },
+    {
+      "bufferView": 1,
+      "byteOffset": 1018128,
+      "componentType": 5126,
+      "count": 12534,
+      "max": [0.124933377, 0.716000438, 0.129168555],
+      "min": [-0.125863016, 0.2958266, -0.1541516],
+      "type": "VEC3",
+      "name": "accessorPositions"
+    },
+    {
+      "bufferView": 2,
+      "byteOffset": 678752,
+      "componentType": 5126,
+      "count": 12534,
+      "type": "VEC4",
+      "name": "accessorTangents"
+    },
+    {
+      "bufferView": 1,
+      "byteOffset": 1168536,
+      "componentType": 5126,
+      "count": 12534,
+      "type": "VEC3",
+      "name": "accessorNormals"
+    },
+    {
+      "bufferView": 3,
+      "byteOffset": 339376,
+      "componentType": 5126,
+      "count": 12534,
+      "type": "VEC2",
+      "name": "accessorUVs"
+    },
+    {
+      "bufferView": 0,
+      "byteOffset": 563916,
+      "componentType": 5123,
+      "count": 2208,
+      "type": "SCALAR",
+      "name": "accessorIndices"
+    },
+    {
+      "bufferView": 1,
+      "byteOffset": 1318944,
+      "componentType": 5126,
+      "count": 436,
+      "max": [0.101920746, 0.5936986, 0.152926728],
+      "min": [-0.101920947, 0.5300429, 0.090174824],
+      "type": "VEC3",
+      "name": "accessorPositions"
+    },
+    {
+      "bufferView": 2,
+      "byteOffset": 879296,
+      "componentType": 5126,
+      "count": 436,
+      "type": "VEC4",
+      "name": "accessorTangents"
+    },
+    {
+      "bufferView": 1,
+      "byteOffset": 1324176,
+      "componentType": 5126,
+      "count": 436,
+      "type": "VEC3",
+      "name": "accessorNormals"
+    },
+    {
+      "bufferView": 3,
+      "byteOffset": 439648,
+      "componentType": 5126,
+      "count": 436,
+      "type": "VEC2",
+      "name": "accessorUVs"
+    }
+  ],
+  "bufferViews": [
+    {
+      "buffer": 0,
+      "byteLength": 568332,
+      "name": "bufferViewScalar"
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 568332,
+      "byteLength": 1329408,
+      "byteStride": 12,
+      "name": "bufferViewFloatVec3"
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 1897740,
+      "byteLength": 886272,
+      "byteStride": 16,
+      "name": "bufferViewFloatVec4"
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 2784012,
+      "byteLength": 443136,
+      "byteStride": 8,
+      "name": "bufferViewFloatVec2"
+    }
+  ],
+  "buffers": [
+    {
+      "uri": "FlightHelmet.bin",
+      "byteLength": 3227148
+    }
+  ],
+  "materials": [
+    {
+      "pbrMetallicRoughness": {
+        "baseColorTexture": {
+          "index": 2
         },
-        {
-            "pbrMetallicRoughness": {
-                "baseColorTexture": {
-                    "index": 2
-                },
-                "metallicRoughnessTexture": {
-                    "index": 1
-                }
-            },
-            "normalTexture": {
-                "index": 0
-            },
-            "occlusionTexture": {
-                "index": 1
-            },
-            "name": "RubberWoodMat"
-        },
-        {
-            "pbrMetallicRoughness": {
-                "baseColorTexture": {
-                    "index": 5
-                },
-                "metallicRoughnessTexture": {
-                    "index": 4
-                }
-            },
-            "normalTexture": {
-                "index": 3
-            },
-            "occlusionTexture": {
-                "index": 4
-            },
-            "name": "GlassPlasticMat"
-        },
-        {
-            "pbrMetallicRoughness": {
-                "baseColorTexture": {
-                    "index": 8
-                },
-                "metallicRoughnessTexture": {
-                    "index": 7
-                }
-            },
-            "normalTexture": {
-                "index": 6
-            },
-            "occlusionTexture": {
-                "index": 7
-            },
-            "name": "MetalPartsMat"
-        },
-        {
-            "pbrMetallicRoughness": {
-                "baseColorTexture": {
-                    "index": 11
-                },
-                "metallicRoughnessTexture": {
-                    "index": 10
-                }
-            },
-            "normalTexture": {
-                "index": 9
-            },
-            "occlusionTexture": {
-                "index": 10
-            },
-            "name": "LeatherPartsMat"
-        },
-        {
-            "pbrMetallicRoughness": {
-                "baseColorTexture": {
-                    "index": 14
-                },
-                "metallicRoughnessTexture": {
-                    "index": 13
-                }
-            },
-            "normalTexture": {
-                "index": 12
-            },
-            "occlusionTexture": {
-                "index": 13
-            },
-            "alphaMode": "BLEND",
-            "name": "LensesMat"
+        "metallicRoughnessTexture": {
+          "index": 1
         }
-    ],
-    "textures": [
-        {
-            "sampler": 0,
-            "source": 0,
-            "name": "FlightHelmet_Materials_RubberWoodMat_Normal.png"
+      },
+      "normalTexture": {
+        "index": 0
+      },
+      "occlusionTexture": {
+        "index": 1
+      },
+      "doubleSided": true,
+      "name": "HoseMat"
+    },
+    {
+      "pbrMetallicRoughness": {
+        "baseColorTexture": {
+          "index": 2
         },
-        {
-            "sampler": 0,
-            "source": 1,
-            "name": "FlightHelmet_Materials_RubberWoodMat_OcclusionRoughMetal.png"
-        },
-        {
-            "sampler": 0,
-            "source": 2,
-            "name": "FlightHelmet_Materials_RubberWoodMat_BaseColor.png"
-        },
-        {
-            "sampler": 0,
-            "source": 3,
-            "name": "FlightHelmet_Materials_GlassPlasticMat_Normal.png"
-        },
-        {
-            "sampler": 0,
-            "source": 4,
-            "name": "FlightHelmet_Materials_GlassPlasticMat_OcclusionRoughMetal.png"
-        },
-        {
-            "sampler": 0,
-            "source": 5,
-            "name": "FlightHelmet_Materials_GlassPlasticMat_BaseColor.png"
-        },
-        {
-            "sampler": 0,
-            "source": 6,
-            "name": "FlightHelmet_Materials_MetalPartsMat_Normal.png"
-        },
-        {
-            "sampler": 0,
-            "source": 7,
-            "name": "FlightHelmet_Materials_MetalPartsMat_OcclusionRoughMetal.png"
-        },
-        {
-            "sampler": 0,
-            "source": 8,
-            "name": "FlightHelmet_Materials_MetalPartsMat_BaseColor.png"
-        },
-        {
-            "sampler": 0,
-            "source": 9,
-            "name": "FlightHelmet_Materials_LeatherPartsMat_Normal.png"
-        },
-        {
-            "sampler": 0,
-            "source": 10,
-            "name": "FlightHelmet_Materials_LeatherPartsMat_OcclusionRoughMetal.png"
-        },
-        {
-            "sampler": 0,
-            "source": 11,
-            "name": "FlightHelmet_Materials_LeatherPartsMat_BaseColor.png"
-        },
-        {
-            "sampler": 0,
-            "source": 12,
-            "name": "FlightHelmet_Materials_LensesMat_Normal.png"
-        },
-        {
-            "sampler": 0,
-            "source": 13,
-            "name": "FlightHelmet_Materials_LensesMat_OcclusionRoughMetal.png"
-        },
-        {
-            "sampler": 0,
-            "source": 14,
-            "name": "FlightHelmet_Materials_LensesMat_BaseColor.png"
+        "metallicRoughnessTexture": {
+          "index": 1
         }
-    ],
-    "images": [
-        {
-            "uri": "FlightHelmet_Materials_RubberWoodMat_Normal.png"
+      },
+      "normalTexture": {
+        "index": 0
+      },
+      "occlusionTexture": {
+        "index": 1
+      },
+      "name": "RubberWoodMat"
+    },
+    {
+      "pbrMetallicRoughness": {
+        "baseColorTexture": {
+          "index": 5
         },
-        {
-            "uri": "FlightHelmet_Materials_RubberWoodMat_OcclusionRoughMetal.png"
-        },
-        {
-            "uri": "FlightHelmet_Materials_RubberWoodMat_BaseColor.png"
-        },
-        {
-            "uri": "FlightHelmet_Materials_GlassPlasticMat_Normal.png"
-        },
-        {
-            "uri": "FlightHelmet_Materials_GlassPlasticMat_OcclusionRoughMetal.png"
-        },
-        {
-            "uri": "FlightHelmet_Materials_GlassPlasticMat_BaseColor.png"
-        },
-        {
-            "uri": "FlightHelmet_Materials_MetalPartsMat_Normal.png"
-        },
-        {
-            "uri": "FlightHelmet_Materials_MetalPartsMat_OcclusionRoughMetal.png"
-        },
-        {
-            "uri": "FlightHelmet_Materials_MetalPartsMat_BaseColor.png"
-        },
-        {
-            "uri": "FlightHelmet_Materials_LeatherPartsMat_Normal.png"
-        },
-        {
-            "uri": "FlightHelmet_Materials_LeatherPartsMat_OcclusionRoughMetal.png"
-        },
-        {
-            "uri": "FlightHelmet_Materials_LeatherPartsMat_BaseColor.png"
-        },
-        {
-            "uri": "FlightHelmet_Materials_LensesMat_Normal.png"
-        },
-        {
-            "uri": "FlightHelmet_Materials_LensesMat_OcclusionRoughMetal.png"
-        },
-        {
-            "uri": "FlightHelmet_Materials_LensesMat_BaseColor.png"
+        "metallicRoughnessTexture": {
+          "index": 4
         }
-    ],
-    "samplers": [
-        {
-            "magFilter": 9729,
-            "minFilter": 9987
+      },
+      "normalTexture": {
+        "index": 3
+      },
+      "occlusionTexture": {
+        "index": 4
+      },
+      "name": "GlassPlasticMat"
+    },
+    {
+      "pbrMetallicRoughness": {
+        "baseColorTexture": {
+          "index": 8
+        },
+        "metallicRoughnessTexture": {
+          "index": 7
         }
-    ]
+      },
+      "normalTexture": {
+        "index": 6
+      },
+      "occlusionTexture": {
+        "index": 7
+      },
+      "name": "MetalPartsMat"
+    },
+    {
+      "pbrMetallicRoughness": {
+        "baseColorTexture": {
+          "index": 11
+        },
+        "metallicRoughnessTexture": {
+          "index": 10
+        }
+      },
+      "normalTexture": {
+        "index": 9
+      },
+      "occlusionTexture": {
+        "index": 10
+      },
+      "name": "LeatherPartsMat"
+    },
+    {
+      "pbrMetallicRoughness": {
+        "baseColorTexture": {
+          "index": 14
+        },
+        "metallicRoughnessTexture": {
+          "index": 13
+        }
+      },
+      "normalTexture": {
+        "index": 12
+      },
+      "occlusionTexture": {
+        "index": 13
+      },
+      "alphaMode": "BLEND",
+      "name": "LensesMat"
+    }
+  ],
+  "textures": [
+    {
+      "sampler": 0,
+      "source": 0,
+      "name": "FlightHelmet_Materials_RubberWoodMat_Normal.png"
+    },
+    {
+      "sampler": 0,
+      "source": 1,
+      "name": "FlightHelmet_Materials_RubberWoodMat_OcclusionRoughMetal.png"
+    },
+    {
+      "sampler": 0,
+      "source": 2,
+      "name": "FlightHelmet_Materials_RubberWoodMat_BaseColor.png"
+    },
+    {
+      "sampler": 0,
+      "source": 3,
+      "name": "FlightHelmet_Materials_GlassPlasticMat_Normal.png"
+    },
+    {
+      "sampler": 0,
+      "source": 4,
+      "name": "FlightHelmet_Materials_GlassPlasticMat_OcclusionRoughMetal.png"
+    },
+    {
+      "sampler": 0,
+      "source": 5,
+      "name": "FlightHelmet_Materials_GlassPlasticMat_BaseColor.png"
+    },
+    {
+      "sampler": 0,
+      "source": 6,
+      "name": "FlightHelmet_Materials_MetalPartsMat_Normal.png"
+    },
+    {
+      "sampler": 0,
+      "source": 7,
+      "name": "FlightHelmet_Materials_MetalPartsMat_OcclusionRoughMetal.png"
+    },
+    {
+      "sampler": 0,
+      "source": 8,
+      "name": "FlightHelmet_Materials_MetalPartsMat_BaseColor.png"
+    },
+    {
+      "sampler": 0,
+      "source": 9,
+      "name": "FlightHelmet_Materials_LeatherPartsMat_Normal.png"
+    },
+    {
+      "sampler": 0,
+      "source": 10,
+      "name": "FlightHelmet_Materials_LeatherPartsMat_OcclusionRoughMetal.png"
+    },
+    {
+      "sampler": 0,
+      "source": 11,
+      "name": "FlightHelmet_Materials_LeatherPartsMat_BaseColor.png"
+    },
+    {
+      "sampler": 0,
+      "source": 12,
+      "name": "FlightHelmet_Materials_LensesMat_Normal.png"
+    },
+    {
+      "sampler": 0,
+      "source": 13,
+      "name": "FlightHelmet_Materials_LensesMat_OcclusionRoughMetal.png"
+    },
+    {
+      "sampler": 0,
+      "source": 14,
+      "name": "FlightHelmet_Materials_LensesMat_BaseColor.png"
+    }
+  ],
+  "images": [
+    {
+      "uri": "FlightHelmet_Materials_RubberWoodMat_Normal.png"
+    },
+    {
+      "uri": "FlightHelmet_Materials_RubberWoodMat_OcclusionRoughMetal.png"
+    },
+    {
+      "uri": "FlightHelmet_Materials_RubberWoodMat_BaseColor.png"
+    },
+    {
+      "uri": "FlightHelmet_Materials_GlassPlasticMat_Normal.png"
+    },
+    {
+      "uri": "FlightHelmet_Materials_GlassPlasticMat_OcclusionRoughMetal.png"
+    },
+    {
+      "uri": "FlightHelmet_Materials_GlassPlasticMat_BaseColor.png"
+    },
+    {
+      "uri": "FlightHelmet_Materials_MetalPartsMat_Normal.png"
+    },
+    {
+      "uri": "FlightHelmet_Materials_MetalPartsMat_OcclusionRoughMetal.png"
+    },
+    {
+      "uri": "FlightHelmet_Materials_MetalPartsMat_BaseColor.png"
+    },
+    {
+      "uri": "FlightHelmet_Materials_LeatherPartsMat_Normal.png"
+    },
+    {
+      "uri": "FlightHelmet_Materials_LeatherPartsMat_OcclusionRoughMetal.png"
+    },
+    {
+      "uri": "FlightHelmet_Materials_LeatherPartsMat_BaseColor.png"
+    },
+    {
+      "uri": "FlightHelmet_Materials_LensesMat_Normal.png"
+    },
+    {
+      "uri": "FlightHelmet_Materials_LensesMat_OcclusionRoughMetal.png"
+    },
+    {
+      "uri": "FlightHelmet_Materials_LensesMat_BaseColor.png"
+    }
+  ],
+  "samplers": [
+    {
+      "magFilter": 9729,
+      "minFilter": 9987
+    }
+  ]
 }

--- a/examples/vite.config.mjs
+++ b/examples/vite.config.mjs
@@ -4,6 +4,7 @@ import wasm from "vite-plugin-wasm";
 
 export default defineConfig({
   build: {
+    minify: false,
     rollupOptions: {
       input: {
         basic: resolve("basic/index.html"),

--- a/examples/vite.config.mjs
+++ b/examples/vite.config.mjs
@@ -1,6 +1,5 @@
 import { resolve } from "path";
 import { defineConfig } from "vite";
-import wasm from "vite-plugin-wasm";
 
 export default defineConfig({
   build: {
@@ -16,9 +15,6 @@ export default defineConfig({
     target: "esnext",
   },
   plugins: [
-    // WASM required for physics
-    wasm(),
-
     // Cross Origin Isolation required for multi-threading
     {
       configureServer: (server) => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,7 +14,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts --onSuccess \"tsc --emitDeclarationOnly\"",
+    "build": "vite build",
     "dev": "pnpm build --watch"
   },
   "dependencies": {
@@ -22,8 +22,8 @@
     "thyseus": "0.12.0-beta.3"
   },
   "devDependencies": {
-    "tsup": "^6.7.0",
-    "typescript": "~5.0.4"
+    "typescript": "~5.0.4",
+    "vite": "^4.3.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,7 +23,8 @@
   },
   "devDependencies": {
     "typescript": "~5.0.4",
-    "vite": "^4.3.4"
+    "vite": "^4.3.4",
+    "vite-plugin-dts": "^2.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/src/scene/cleanup.ts
+++ b/packages/core/src/scene/cleanup.ts
@@ -1,7 +1,12 @@
-import { Commands,   CommandsDescriptor,
-Entity, Query,   QueryDescriptor,
-Res,   ResourceDescriptor,
-SystemRes ,
+import {
+  Commands,
+  CommandsDescriptor,
+  Entity,
+  Query,
+  QueryDescriptor,
+  Res,
+  ResourceDescriptor,
+  SystemRes,
   SystemResourceDescriptor,
 } from "thyseus";
 

--- a/packages/core/vite.config.mjs
+++ b/packages/core/vite.config.mjs
@@ -11,6 +11,9 @@ export default defineConfig({
       name: "core",
     },
     minify: false,
+    rollupOptions: {
+      external: ["thyseus"],
+    },
     target: "esnext",
   },
   plugins: [dts()],

--- a/packages/core/vite.config.mjs
+++ b/packages/core/vite.config.mjs
@@ -1,0 +1,24 @@
+import { exec } from "child_process";
+import { resolve } from "path";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: resolve("src/index.ts"),
+      fileName: "index",
+      formats: ["es"],
+      name: "core",
+    },
+    minify: false,
+    target: "esnext",
+  },
+  plugins: [
+    {
+      buildEnd() {
+        exec("tsc --emitDeclarationOnly");
+      },
+      name: "dts",
+    },
+  ],
+});

--- a/packages/core/vite.config.mjs
+++ b/packages/core/vite.config.mjs
@@ -1,6 +1,6 @@
-import { exec } from "child_process";
 import { resolve } from "path";
 import { defineConfig } from "vite";
+import dts from "vite-plugin-dts";
 
 export default defineConfig({
   build: {
@@ -13,12 +13,5 @@ export default defineConfig({
     minify: false,
     target: "esnext",
   },
-  plugins: [
-    {
-      buildEnd() {
-        exec("tsc --emitDeclarationOnly");
-      },
-      name: "dts",
-    },
-  ],
+  plugins: [dts()],
 });

--- a/packages/gltf/package.json
+++ b/packages/gltf/package.json
@@ -14,7 +14,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts --onSuccess \"tsc --emitDeclarationOnly\"",
+    "build": "vite build",
     "dev": "pnpm build --watch"
   },
   "dependencies": {
@@ -24,8 +24,9 @@
     "thyseus": "0.12.0-beta.3"
   },
   "devDependencies": {
-    "tsup": "^6.7.0",
-    "typescript": "~5.0.4"
+    "typescript": "~5.0.4",
+    "vite": "^4.3.4",
+    "vite-plugin-dts": "^2.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/gltf/src/loader/gltfCleanup.ts
+++ b/packages/gltf/src/loader/gltfCleanup.ts
@@ -1,8 +1,13 @@
 import { Warehouse } from "@lattice-engine/core";
-import { Commands,   CommandsDescriptor,
-Entity, Query,   QueryDescriptor,
-Res,   ResourceDescriptor,
-SystemRes ,
+import {
+  Commands,
+  CommandsDescriptor,
+  Entity,
+  Query,
+  QueryDescriptor,
+  Res,
+  ResourceDescriptor,
+  SystemRes,
   SystemResourceDescriptor,
 } from "thyseus";
 

--- a/packages/gltf/src/loader/gltfLoader.ts
+++ b/packages/gltf/src/loader/gltfLoader.ts
@@ -1,9 +1,14 @@
 import { Document, WebIO } from "@gltf-transform/core";
 import { Warehouse } from "@lattice-engine/core";
-import { Commands,   CommandsDescriptor,
-Entity, Query,   QueryDescriptor,
-Res,   ResourceDescriptor,
-SystemRes ,
+import {
+  Commands,
+  CommandsDescriptor,
+  Entity,
+  Query,
+  QueryDescriptor,
+  Res,
+  ResourceDescriptor,
+  SystemRes,
   SystemResourceDescriptor,
 } from "thyseus";
 

--- a/packages/gltf/vite.config.mjs
+++ b/packages/gltf/vite.config.mjs
@@ -1,0 +1,20 @@
+import { resolve } from "path";
+import { defineConfig } from "vite";
+import dts from "vite-plugin-dts";
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: resolve("src/index.ts"),
+      fileName: "index",
+      formats: ["es"],
+      name: "gltf",
+    },
+    minify: false,
+    rollupOptions: {
+      external: ["thyseus", "@lattice-engine/core"],
+    },
+    target: "esnext",
+  },
+  plugins: [dts()],
+});

--- a/packages/orbit/package.json
+++ b/packages/orbit/package.json
@@ -14,7 +14,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts --onSuccess \"tsc --emitDeclarationOnly\"",
+    "build": "vite build",
     "dev": "pnpm build --watch"
   },
   "dependencies": {
@@ -25,8 +25,9 @@
   },
   "devDependencies": {
     "@types/three": "^0.149.0",
-    "tsup": "^6.7.0",
-    "typescript": "~5.0.4"
+    "typescript": "~5.0.4",
+    "vite": "^4.3.4",
+    "vite-plugin-dts": "^2.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/orbit/vite.config.mjs
+++ b/packages/orbit/vite.config.mjs
@@ -1,0 +1,20 @@
+import { resolve } from "path";
+import { defineConfig } from "vite";
+import dts from "vite-plugin-dts";
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: resolve("src/index.ts"),
+      fileName: "index",
+      formats: ["es"],
+      name: "orbit",
+    },
+    minify: false,
+    rollupOptions: {
+      external: ["thyseus", "@lattice-engine/core", "@lattice-engine/render"],
+    },
+    target: "esnext",
+  },
+  plugins: [dts()],
+});

--- a/packages/physics/package.json
+++ b/packages/physics/package.json
@@ -14,7 +14,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts --onSuccess \"tsc --emitDeclarationOnly\"",
+    "build": "vite build",
     "dev": "pnpm build --watch"
   },
   "dependencies": {
@@ -23,8 +23,10 @@
     "thyseus": "0.12.0-beta.3"
   },
   "devDependencies": {
-    "tsup": "^6.7.0",
-    "typescript": "~5.0.4"
+    "typescript": "~5.0.4",
+    "vite": "^4.3.4",
+    "vite-plugin-dts": "^2.3.0",
+    "vite-plugin-wasm": "^3.2.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/physics/vite.config.mjs
+++ b/packages/physics/vite.config.mjs
@@ -1,0 +1,21 @@
+import { resolve } from "path";
+import { defineConfig } from "vite";
+import dts from "vite-plugin-dts";
+import wasm from "vite-plugin-wasm";
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: resolve("src/index.ts"),
+      fileName: "index",
+      formats: ["es"],
+      name: "physics",
+    },
+    minify: false,
+    rollupOptions: {
+      external: ["thyseus", "@lattice-engine/core"],
+    },
+    target: "esnext",
+  },
+  plugins: [dts(), wasm()],
+});

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -14,7 +14,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts --onSuccess \"tsc --emitDeclarationOnly\"",
+    "build": "vite build",
     "dev": "pnpm build --watch"
   },
   "dependencies": {
@@ -24,8 +24,9 @@
   },
   "devDependencies": {
     "@types/three": "^0.149.0",
-    "tsup": "^6.7.0",
-    "typescript": "~5.0.4"
+    "typescript": "~5.0.4",
+    "vite": "^4.3.4",
+    "vite-plugin-dts": "^2.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/render/src/scene/cameraBuilder.ts
+++ b/packages/render/src/scene/cameraBuilder.ts
@@ -1,6 +1,14 @@
 import { PerspectiveCamera, Position } from "@lattice-engine/core";
 import { PerspectiveCamera as ThreePerspectiveCamera } from "three";
-import { Entity, Query, QueryDescriptor, Res, ResourceDescriptor,With, WithDescriptor  } from "thyseus";
+import {
+  Entity,
+  Query,
+  QueryDescriptor,
+  Res,
+  ResourceDescriptor,
+  With,
+  WithDescriptor,
+} from "thyseus";
 
 import { RenderStore } from "../RenderStore";
 

--- a/packages/render/src/scene/geometryBuilder.ts
+++ b/packages/render/src/scene/geometryBuilder.ts
@@ -1,6 +1,12 @@
 import { Geometry, Warehouse } from "@lattice-engine/core";
 import { BufferAttribute, BufferGeometry } from "three";
-import { Entity, Query, QueryDescriptor, Res , ResourceDescriptor } from "thyseus";
+import {
+  Entity,
+  Query,
+  QueryDescriptor,
+  Res,
+  ResourceDescriptor,
+} from "thyseus";
 
 import { RenderStore } from "../RenderStore";
 

--- a/packages/render/src/scene/nodeBuilder.ts
+++ b/packages/render/src/scene/nodeBuilder.ts
@@ -6,7 +6,15 @@ import {
   Scale,
 } from "@lattice-engine/core";
 import { Object3D } from "three";
-import { Entity, Query, QueryDescriptor, Res, ResourceDescriptor,With, WithDescriptor  } from "thyseus";
+import {
+  Entity,
+  Query,
+  QueryDescriptor,
+  Res,
+  ResourceDescriptor,
+  With,
+  WithDescriptor,
+} from "thyseus";
 
 import { RenderStore } from "../RenderStore";
 

--- a/packages/render/vite.config.mjs
+++ b/packages/render/vite.config.mjs
@@ -1,0 +1,20 @@
+import { resolve } from "path";
+import { defineConfig } from "vite";
+import dts from "vite-plugin-dts";
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: resolve("src/index.ts"),
+      fileName: "index",
+      formats: ["es"],
+      name: "render",
+    },
+    minify: false,
+    rollupOptions: {
+      external: ["thyseus", "@lattice-engine/core"],
+    },
+    target: "esnext",
+  },
+  plugins: [dts()],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       vite:
         specifier: ^4.3.4
         version: 4.3.4
+      vite-plugin-dts:
+        specifier: ^2.3.0
+        version: 2.3.0(vite@4.3.4)
 
   packages/gltf:
     dependencies:
@@ -192,6 +195,33 @@ importers:
         version: 5.0.4
 
 packages:
+
+  /@babel/helper-string-parser@7.21.5:
+    resolution: {integrity: sha512-5pTUx3hAJaZIdW99sJ6ZUUgWq/Y+Hja7TowEnLNMm1VivRgZQL3vpBY3qUACVsvw+yQU6+YgfBVmcbLaZtrA1w==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/helper-validator-identifier@7.19.1:
+    resolution: {integrity: sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/parser@7.21.8:
+    resolution: {integrity: sha512-6zavDGdzG3gUqAdWvlLFfk+36RilI+Pwyuuh7HItyeScCWP3k6i8vKclAQ0bM/0y/Kz/xiwvxhMv9MgTJP5gmA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/types': 7.21.5
+    dev: true
+
+  /@babel/types@7.21.5:
+    resolution: {integrity: sha512-m4AfNvVF2mVC/F7fDEdH2El3HzUg9It/XsCxZiOTTA3m3qYfcSVSbTfM6Q9xG+hYDniZssYhlXKKUMD5m8tF4Q==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.21.5
+      '@babel/helper-validator-identifier': 7.19.1
+      to-fast-properties: 2.0.0
+    dev: true
 
   /@dimforge/rapier3d@0.11.2:
     resolution: {integrity: sha512-B+AKkPmtJxED3goMTGU8v0ju8hUAUQGLgghzCos4G4OeN9X+mJ5lfN2xtNA0n8tJRJk2YfsMk9BOj/6AN89Acg==}
@@ -504,6 +534,49 @@ packages:
     engines: {node: '>=12'}
     dev: false
 
+  /@microsoft/api-extractor-model@7.26.9:
+    resolution: {integrity: sha512-1AowqcRy5qMH/OB7UNkdXa4qLoJp58WFdJ026IMFS8skA0OOAOcvBV/Fi4L7fO1R/8uCMz5KHi3NsqVH4Li8xg==}
+    dependencies:
+      '@microsoft/tsdoc': 0.14.2
+      '@microsoft/tsdoc-config': 0.16.2
+      '@rushstack/node-core-library': 3.59.0
+    transitivePeerDependencies:
+      - '@types/node'
+    dev: true
+
+  /@microsoft/api-extractor@7.34.9:
+    resolution: {integrity: sha512-dasBIbqgHgxvfRfEOX4+ynNYQPnTYc6k7jkL3V4f/MoaS2xFUoIj/D71crrsDxf5MNMybjzeyZPdRNZdzvKBVw==}
+    hasBin: true
+    dependencies:
+      '@microsoft/api-extractor-model': 7.26.9
+      '@microsoft/tsdoc': 0.14.2
+      '@microsoft/tsdoc-config': 0.16.2
+      '@rushstack/node-core-library': 3.59.0
+      '@rushstack/rig-package': 0.3.18
+      '@rushstack/ts-command-line': 4.13.2
+      colors: 1.2.5
+      lodash: 4.17.21
+      resolve: 1.22.2
+      semver: 7.3.8
+      source-map: 0.6.1
+      typescript: 4.8.4
+    transitivePeerDependencies:
+      - '@types/node'
+    dev: true
+
+  /@microsoft/tsdoc-config@0.16.2:
+    resolution: {integrity: sha512-OGiIzzoBLgWWR0UdRJX98oYO+XKGf7tiK4Zk6tQ/E4IJqGCe7dvkTvgDZV5cFJUzLGDOjeAXrnZoA6QkVySuxw==}
+    dependencies:
+      '@microsoft/tsdoc': 0.14.2
+      ajv: 6.12.6
+      jju: 1.4.0
+      resolve: 1.19.0
+    dev: true
+
+  /@microsoft/tsdoc@0.14.2:
+    resolution: {integrity: sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==}
+    dev: true
+
   /@nodelib/fs.scandir@2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -535,6 +608,70 @@ packages:
       open: 9.1.0
       picocolors: 1.0.0
       tslib: 2.5.0
+    dev: true
+
+  /@rollup/pluginutils@5.0.2:
+    resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@types/estree': 1.0.1
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+    dev: true
+
+  /@rushstack/node-core-library@3.59.0:
+    resolution: {integrity: sha512-f8ilzooAu8vj60dDe7weqHvR1NujOaKfe3TaNgAoT22rk+daUTmDtY3TlVGJ3HayVPmw3ffWToDatITi7Ic4ag==}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+    dependencies:
+      colors: 1.2.5
+      fs-extra: 7.0.1
+      import-lazy: 4.0.0
+      jju: 1.4.0
+      resolve: 1.22.2
+      semver: 7.3.8
+      z-schema: 5.0.5
+    dev: true
+
+  /@rushstack/rig-package@0.3.18:
+    resolution: {integrity: sha512-SGEwNTwNq9bI3pkdd01yCaH+gAsHqs0uxfGvtw9b0LJXH52qooWXnrFTRRLG1aL9pf+M2CARdrA9HLHJys3jiQ==}
+    dependencies:
+      resolve: 1.22.2
+      strip-json-comments: 3.1.1
+    dev: true
+
+  /@rushstack/ts-command-line@4.13.2:
+    resolution: {integrity: sha512-bCU8qoL9HyWiciltfzg7GqdfODUeda/JpI0602kbN5YH22rzTxyqYvv7aRLENCM7XCQ1VRs7nMkEqgJUOU8Sag==}
+    dependencies:
+      '@types/argparse': 1.0.38
+      argparse: 1.0.10
+      colors: 1.2.5
+      string-argv: 0.3.2
+    dev: true
+
+  /@ts-morph/common@0.19.0:
+    resolution: {integrity: sha512-Unz/WHmd4pGax91rdIKWi51wnVUW11QttMEPpBiBgIewnc9UQIX7UDLxr5vRlqeByXCwhkF6VabSsI0raWcyAQ==}
+    dependencies:
+      fast-glob: 3.2.12
+      minimatch: 7.4.6
+      mkdirp: 2.1.6
+      path-browserify: 1.0.1
+    dev: true
+
+  /@types/argparse@1.0.38:
+    resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
+    dev: true
+
+  /@types/estree@1.0.1:
+    resolution: {integrity: sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==}
     dev: true
 
   /@types/json-schema@7.0.11:
@@ -750,6 +887,12 @@ packages:
       picomatch: 2.3.1
     dev: true
 
+  /argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+    dependencies:
+      sprintf-js: 1.0.3
+    dev: true
+
   /argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
     dev: true
@@ -830,6 +973,12 @@ packages:
       concat-map: 0.0.1
     dev: true
 
+  /brace-expansion@2.0.1:
+    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+    dependencies:
+      balanced-match: 1.0.2
+    dev: true
+
   /braces@3.0.2:
     resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
     engines: {node: '>=8'}
@@ -894,6 +1043,10 @@ packages:
       fsevents: 2.3.2
     dev: true
 
+  /code-block-writer@12.0.0:
+    resolution: {integrity: sha512-q4dMFMlXtKR3XNBHyMHt/3pwYNA69EDk00lloMOaaUMKPUXBw6lpXtbu3MMVG6/uOihGnRDOlkyqsONEUj60+w==}
+    dev: true
+
   /color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -905,10 +1058,22 @@ packages:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
     dev: true
 
+  /colors@1.2.5:
+    resolution: {integrity: sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==}
+    engines: {node: '>=0.1.90'}
+    dev: true
+
   /commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
     dev: true
+
+  /commander@9.5.0:
+    resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
+    engines: {node: ^12.20.0 || >=14}
+    requiresBuild: true
+    dev: true
+    optional: true
 
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -1438,6 +1603,10 @@ packages:
     engines: {node: '>=4.0'}
     dev: true
 
+  /estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+    dev: true
+
   /esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -1540,6 +1709,24 @@ packages:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
     dependencies:
       is-callable: 1.2.7
+    dev: true
+
+  /fs-extra@10.1.0:
+    resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.1.0
+      universalify: 2.0.0
+    dev: true
+
+  /fs-extra@7.0.1:
+    resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
+    engines: {node: '>=6 <7 || >=8'}
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 4.0.0
+      universalify: 0.1.2
     dev: true
 
   /fs.realpath@1.0.0:
@@ -1750,6 +1937,11 @@ packages:
       resolve-from: 4.0.0
     dev: true
 
+  /import-lazy@4.0.0:
+    resolution: {integrity: sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==}
+    engines: {node: '>=8'}
+    dev: true
+
   /imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
@@ -1947,6 +2139,10 @@ packages:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
     dev: true
 
+  /jju@1.4.0:
+    resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
+    dev: true
+
   /joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
@@ -1988,6 +2184,24 @@ packages:
       semver: 7.5.0
     dev: true
 
+  /jsonfile@4.0.0:
+    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
+    optionalDependencies:
+      graceful-fs: 4.2.11
+    dev: true
+
+  /jsonfile@6.1.0:
+    resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
+    dependencies:
+      universalify: 2.0.0
+    optionalDependencies:
+      graceful-fs: 4.2.11
+    dev: true
+
+  /kolorist@1.8.0:
+    resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
+    dev: true
+
   /ktx-parse@0.5.0:
     resolution: {integrity: sha512-5IZrv5s1byUeDTIee1jjJQBiD5LPDB0w9pJJ0oT9BCKKJf16Tuj123vm1Ps0GOHSHmeWPgKM0zuViCVuTRpqaA==}
     dev: false
@@ -2021,6 +2235,14 @@ packages:
       p-locate: 5.0.0
     dev: true
 
+  /lodash.get@4.4.2:
+    resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
+    dev: true
+
+  /lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    dev: true
+
   /lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
     dev: true
@@ -2029,11 +2251,22 @@ packages:
     resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
     dev: true
 
+  /lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+    dev: true
+
   /lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
     dependencies:
       yallist: 4.0.0
+    dev: true
+
+  /magic-string@0.29.0:
+    resolution: {integrity: sha512-WcfidHrDjMY+eLjlU+8OvwREqHwpgCeKVBUpQ3OhYYuvfaYCUgcbuBzappNzZvg/v8onU3oQj+BYpkOJe9Iw4Q==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
   /merge-stream@2.0.0:
@@ -2069,12 +2302,25 @@ packages:
       brace-expansion: 1.1.11
     dev: true
 
+  /minimatch@7.4.6:
+    resolution: {integrity: sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==}
+    engines: {node: '>=10'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: true
+
   /minimist@0.0.10:
     resolution: {integrity: sha512-iotkTvxc+TwOm5Ieim8VnSNvCDjCK9S8G3scJ50ZthspSxa7jx50jkhYduuAtAjvfDUwSgOwf8+If99AlOEhyw==}
     dev: true
 
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+    dev: true
+
+  /mkdirp@2.1.6:
+    resolution: {integrity: sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==}
+    engines: {node: '>=10'}
+    hasBin: true
     dev: true
 
   /ms@2.1.2:
@@ -2232,6 +2478,10 @@ packages:
       callsites: 3.1.0
     dev: true
 
+  /path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+    dev: true
+
   /path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -2368,6 +2618,13 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /resolve@1.19.0:
+    resolution: {integrity: sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==}
+    dependencies:
+      is-core-module: 2.12.0
+      path-parse: 1.0.7
+    dev: true
+
   /resolve@1.22.2:
     resolution: {integrity: sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==}
     hasBin: true
@@ -2421,6 +2678,14 @@ packages:
   /semver@6.3.0:
     resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==}
     hasBin: true
+    dev: true
+
+  /semver@7.3.8:
+    resolution: {integrity: sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      lru-cache: 6.0.0
     dev: true
 
   /semver@7.5.0:
@@ -2486,11 +2751,25 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
   /source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
     dependencies:
       whatwg-url: 7.1.0
+    dev: true
+
+  /sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+    dev: true
+
+  /string-argv@0.3.2:
+    resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
+    engines: {node: '>=0.6.19'}
     dev: true
 
   /string.prototype.trim@1.2.7:
@@ -2616,6 +2895,11 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
+  /to-fast-properties@2.0.0:
+    resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
+    engines: {node: '>=4'}
+    dev: true
+
   /to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -2636,6 +2920,13 @@ packages:
 
   /ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+    dev: true
+
+  /ts-morph@18.0.0:
+    resolution: {integrity: sha512-Kg5u0mk19PIIe4islUI/HWRvm9bC1lHejK4S0oh1zaZ77TMZAEmQC0sHQYiu2RgCQFZKXz1fMVi/7nOOeirznA==}
+    dependencies:
+      '@ts-morph/common': 0.19.0
+      code-block-writer: 12.0.0
     dev: true
 
   /tsconfig-paths@3.14.2:
@@ -2782,6 +3073,12 @@ packages:
       is-typed-array: 1.1.10
     dev: true
 
+  /typescript@4.8.4:
+    resolution: {integrity: sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
+    dev: true
+
   /typescript@5.0.4:
     resolution: {integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==}
     engines: {node: '>=12.20'}
@@ -2797,6 +3094,16 @@ packages:
       which-boxed-primitive: 1.0.2
     dev: true
 
+  /universalify@0.1.2:
+    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
+    engines: {node: '>= 4.0.0'}
+    dev: true
+
+  /universalify@2.0.0:
+    resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
+    engines: {node: '>= 10.0.0'}
+    dev: true
+
   /untildify@4.0.0:
     resolution: {integrity: sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==}
     engines: {node: '>=8'}
@@ -2806,6 +3113,34 @@ packages:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
     dependencies:
       punycode: 2.3.0
+    dev: true
+
+  /validator@13.9.0:
+    resolution: {integrity: sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA==}
+    engines: {node: '>= 0.10'}
+    dev: true
+
+  /vite-plugin-dts@2.3.0(vite@4.3.4):
+    resolution: {integrity: sha512-WbJgGtsStgQhdm3EosYmIdTGbag5YQpZ3HXWUAPCDyoXI5qN6EY0V7NXq0lAmnv9hVQsvh0htbYcg0Or5Db9JQ==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: '>=2.9.0'
+    dependencies:
+      '@babel/parser': 7.21.8
+      '@microsoft/api-extractor': 7.34.9
+      '@rollup/pluginutils': 5.0.2
+      '@rushstack/node-core-library': 3.59.0
+      debug: 4.3.4
+      fast-glob: 3.2.12
+      fs-extra: 10.1.0
+      kolorist: 1.8.0
+      magic-string: 0.29.0
+      ts-morph: 18.0.0
+      vite: 4.3.4
+    transitivePeerDependencies:
+      - '@types/node'
+      - rollup
+      - supports-color
     dev: true
 
   /vite-plugin-wasm@3.2.2(vite@4.3.4):
@@ -2916,4 +3251,16 @@ packages:
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+    dev: true
+
+  /z-schema@5.0.5:
+    resolution: {integrity: sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==}
+    engines: {node: '>=8.0.0'}
+    hasBin: true
+    dependencies:
+      lodash.get: 4.4.2
+      lodash.isequal: 4.5.0
+      validator: 13.9.0
+    optionalDependencies:
+      commander: 9.5.0
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,9 +83,6 @@ importers:
       vite:
         specifier: ^4.3.4
         version: 4.3.4
-      vite-plugin-wasm:
-        specifier: ^3.2.2
-        version: 3.2.2(vite@4.3.4)
 
   packages/core:
     dependencies:
@@ -121,12 +118,15 @@ importers:
         specifier: 0.12.0-beta.3
         version: 0.12.0-beta.3
     devDependencies:
-      tsup:
-        specifier: ^6.7.0
-        version: 6.7.0(typescript@5.0.4)
       typescript:
         specifier: ~5.0.4
         version: 5.0.4
+      vite:
+        specifier: ^4.3.4
+        version: 4.3.4
+      vite-plugin-dts:
+        specifier: ^2.3.0
+        version: 2.3.0(vite@4.3.4)
 
   packages/orbit:
     dependencies:
@@ -146,12 +146,15 @@ importers:
       '@types/three':
         specifier: ^0.149.0
         version: 0.149.0
-      tsup:
-        specifier: ^6.7.0
-        version: 6.7.0(typescript@5.0.4)
       typescript:
         specifier: ~5.0.4
         version: 5.0.4
+      vite:
+        specifier: ^4.3.4
+        version: 4.3.4
+      vite-plugin-dts:
+        specifier: ^2.3.0
+        version: 2.3.0(vite@4.3.4)
 
   packages/physics:
     dependencies:
@@ -165,12 +168,18 @@ importers:
         specifier: 0.12.0-beta.3
         version: 0.12.0-beta.3
     devDependencies:
-      tsup:
-        specifier: ^6.7.0
-        version: 6.7.0(typescript@5.0.4)
       typescript:
         specifier: ~5.0.4
         version: 5.0.4
+      vite:
+        specifier: ^4.3.4
+        version: 4.3.4
+      vite-plugin-dts:
+        specifier: ^2.3.0
+        version: 2.3.0(vite@4.3.4)
+      vite-plugin-wasm:
+        specifier: ^3.2.2
+        version: 3.2.2(vite@4.3.4)
 
   packages/render:
     dependencies:
@@ -187,12 +196,15 @@ importers:
       '@types/three':
         specifier: ^0.149.0
         version: 0.149.0
-      tsup:
-        specifier: ^6.7.0
-        version: 6.7.0(typescript@5.0.4)
       typescript:
         specifier: ~5.0.4
         version: 5.0.4
+      vite:
+        specifier: ^4.3.4
+        version: 4.3.4
+      vite-plugin-dts:
+        specifier: ^2.3.0
+        version: 2.3.0(vite@4.3.4)
 
 packages:
 
@@ -495,38 +507,8 @@ packages:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
     dev: true
 
-  /@jridgewell/gen-mapping@0.3.3:
-    resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==}
-    engines: {node: '>=6.0.0'}
-    dependencies:
-      '@jridgewell/set-array': 1.1.2
-      '@jridgewell/sourcemap-codec': 1.4.15
-      '@jridgewell/trace-mapping': 0.3.18
-    dev: true
-
-  /@jridgewell/resolve-uri@3.1.0:
-    resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==}
-    engines: {node: '>=6.0.0'}
-    dev: true
-
-  /@jridgewell/set-array@1.1.2:
-    resolution: {integrity: sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==}
-    engines: {node: '>=6.0.0'}
-    dev: true
-
-  /@jridgewell/sourcemap-codec@1.4.14:
-    resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
-    dev: true
-
   /@jridgewell/sourcemap-codec@1.4.15:
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
-    dev: true
-
-  /@jridgewell/trace-mapping@0.3.18:
-    resolution: {integrity: sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==}
-    dependencies:
-      '@jridgewell/resolve-uri': 3.1.0
-      '@jridgewell/sourcemap-codec': 1.4.14
     dev: true
 
   /@lastolivegames/becsy@0.14.3:
@@ -875,18 +857,6 @@ packages:
       color-convert: 2.0.1
     dev: true
 
-  /any-promise@1.3.0:
-    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
-    dev: true
-
-  /anymatch@3.1.3:
-    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
-    engines: {node: '>= 8'}
-    dependencies:
-      normalize-path: 3.0.0
-      picomatch: 2.3.1
-    dev: true
-
   /argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
     dependencies:
@@ -954,11 +924,6 @@ packages:
     engines: {node: '>=0.6'}
     dev: true
 
-  /binary-extensions@2.2.0:
-    resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
-    engines: {node: '>=8'}
-    dev: true
-
   /bplist-parser@0.2.0:
     resolution: {integrity: sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==}
     engines: {node: '>= 5.10.0'}
@@ -993,21 +958,6 @@ packages:
       run-applescript: 5.0.0
     dev: true
 
-  /bundle-require@4.0.1(esbuild@0.17.18):
-    resolution: {integrity: sha512-9NQkRHlNdNpDBGmLpngF3EFDcwodhMUuLz9PaWYciVcQF9SE4LFjM2DB/xV1Li5JiuDMv7ZUWuC3rGbqR0MAXQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    peerDependencies:
-      esbuild: '>=0.17'
-    dependencies:
-      esbuild: 0.17.18
-      load-tsconfig: 0.2.5
-    dev: true
-
-  /cac@6.7.14:
-    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
-    engines: {node: '>=8'}
-    dev: true
-
   /call-bind@1.0.2:
     resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
     dependencies:
@@ -1028,21 +978,6 @@ packages:
       supports-color: 7.2.0
     dev: true
 
-  /chokidar@3.5.3:
-    resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
-    engines: {node: '>= 8.10.0'}
-    dependencies:
-      anymatch: 3.1.3
-      braces: 3.0.2
-      glob-parent: 5.1.2
-      is-binary-path: 2.1.0
-      is-glob: 4.0.3
-      normalize-path: 3.0.0
-      readdirp: 3.6.0
-    optionalDependencies:
-      fsevents: 2.3.2
-    dev: true
-
   /code-block-writer@12.0.0:
     resolution: {integrity: sha512-q4dMFMlXtKR3XNBHyMHt/3pwYNA69EDk00lloMOaaUMKPUXBw6lpXtbu3MMVG6/uOihGnRDOlkyqsONEUj60+w==}
     dev: true
@@ -1061,11 +996,6 @@ packages:
   /colors@1.2.5:
     resolution: {integrity: sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==}
     engines: {node: '>=0.1.90'}
-    dev: true
-
-  /commander@4.1.1:
-    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
-    engines: {node: '>= 6'}
     dev: true
 
   /commander@9.5.0:
@@ -1802,17 +1732,6 @@ packages:
       is-glob: 4.0.3
     dev: true
 
-  /glob@7.1.6:
-    resolution: {integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==}
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.1.2
-      once: 1.4.0
-      path-is-absolute: 1.0.1
-    dev: true
-
   /glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     dependencies:
@@ -1981,13 +1900,6 @@ packages:
       has-bigints: 1.0.2
     dev: true
 
-  /is-binary-path@2.1.0:
-    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
-    engines: {node: '>=8'}
-    dependencies:
-      binary-extensions: 2.2.0
-    dev: true
-
   /is-boolean-object@1.1.2:
     resolution: {integrity: sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==}
     engines: {node: '>= 0.4'}
@@ -2143,11 +2055,6 @@ packages:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
     dev: true
 
-  /joycon@3.1.1:
-    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
-    engines: {node: '>=10'}
-    dev: true
-
   /js-sdsl@4.4.0:
     resolution: {integrity: sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==}
     dev: true
@@ -2214,20 +2121,6 @@ packages:
       type-check: 0.4.0
     dev: true
 
-  /lilconfig@2.1.0:
-    resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
-    engines: {node: '>=10'}
-    dev: true
-
-  /lines-and-columns@1.2.4:
-    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
-    dev: true
-
-  /load-tsconfig@0.2.5:
-    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dev: true
-
   /locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -2245,10 +2138,6 @@ packages:
 
   /lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
-    dev: true
-
-  /lodash.sortby@4.7.0:
-    resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
     dev: true
 
   /lodash@4.17.21:
@@ -2327,14 +2216,6 @@ packages:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
     dev: true
 
-  /mz@2.7.0:
-    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
-    dependencies:
-      any-promise: 1.3.0
-      object-assign: 4.1.1
-      thenify-all: 1.6.0
-    dev: true
-
   /nanoid@3.3.6:
     resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -2349,11 +2230,6 @@ packages:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
     dev: true
 
-  /normalize-path@3.0.0:
-    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
   /npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
@@ -2366,11 +2242,6 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       path-key: 4.0.0
-    dev: true
-
-  /object-assign@4.1.1:
-    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
-    engines: {node: '>=0.10.0'}
     dev: true
 
   /object-inspect@1.12.3:
@@ -2520,27 +2391,6 @@ packages:
     engines: {node: '>=8.6'}
     dev: true
 
-  /pirates@4.0.5:
-    resolution: {integrity: sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==}
-    engines: {node: '>= 6'}
-    dev: true
-
-  /postcss-load-config@3.1.4:
-    resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
-    engines: {node: '>= 10'}
-    peerDependencies:
-      postcss: '>=8.0.9'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      postcss:
-        optional: true
-      ts-node:
-        optional: true
-    dependencies:
-      lilconfig: 2.1.0
-      yaml: 1.10.2
-    dev: true
-
   /postcss@8.4.23:
     resolution: {integrity: sha512-bQ3qMcpF6A/YjR55xtoTr0jGOlnPOKAIMdOWiv0EIT6HVPEaJiJB4NLljSbiHoC2RX7DN5Uvjtpbg1NPdwv1oA==}
     engines: {node: ^10 || ^12 || >=14}
@@ -2587,13 +2437,6 @@ packages:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
     dev: true
 
-  /readdirp@3.6.0:
-    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
-    engines: {node: '>=8.10.0'}
-    dependencies:
-      picomatch: 2.3.1
-    dev: true
-
   /regexp.prototype.flags@1.5.0:
     resolution: {integrity: sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==}
     engines: {node: '>= 0.4'}
@@ -2611,11 +2454,6 @@ packages:
   /resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
-    dev: true
-
-  /resolve-from@5.0.0:
-    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
-    engines: {node: '>=8'}
     dev: true
 
   /resolve@1.19.0:
@@ -2756,13 +2594,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /source-map@0.8.0-beta.0:
-    resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
-    engines: {node: '>= 8'}
-    dependencies:
-      whatwg-url: 7.1.0
-    dev: true
-
   /sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
     dev: true
@@ -2824,20 +2655,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /sucrase@3.32.0:
-    resolution: {integrity: sha512-ydQOU34rpSyj2TGyz4D2p8rbktIOZ8QY9s+DGLvFU1i5pWJE8vkpruCjGCMHsdXwnD7JDcS+noSwM/a7zyNFDQ==}
-    engines: {node: '>=8'}
-    hasBin: true
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.3
-      commander: 4.1.1
-      glob: 7.1.6
-      lines-and-columns: 1.2.4
-      mz: 2.7.0
-      pirates: 4.0.5
-      ts-interface-checker: 0.1.13
-    dev: true
-
   /supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -2867,19 +2684,6 @@ packages:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
     dev: true
 
-  /thenify-all@1.6.0:
-    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
-    engines: {node: '>=0.8'}
-    dependencies:
-      thenify: 3.3.1
-    dev: true
-
-  /thenify@3.3.1:
-    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
-    dependencies:
-      any-promise: 1.3.0
-    dev: true
-
   /three@0.149.0:
     resolution: {integrity: sha512-tohpUxPDht0qExRLDTM8sjRLc5d9STURNrdnK3w9A+V4pxaTBfKWWT/IqtiLfg23Vfc3Z+ImNfvRw1/0CtxrkQ==}
     dev: false
@@ -2907,21 +2711,6 @@ packages:
       is-number: 7.0.0
     dev: true
 
-  /tr46@1.0.1:
-    resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
-    dependencies:
-      punycode: 2.3.0
-    dev: true
-
-  /tree-kill@1.2.2:
-    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
-    hasBin: true
-    dev: true
-
-  /ts-interface-checker@0.1.13:
-    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
-    dev: true
-
   /ts-morph@18.0.0:
     resolution: {integrity: sha512-Kg5u0mk19PIIe4islUI/HWRvm9bC1lHejK4S0oh1zaZ77TMZAEmQC0sHQYiu2RgCQFZKXz1fMVi/7nOOeirznA==}
     dependencies:
@@ -2944,42 +2733,6 @@ packages:
 
   /tslib@2.5.0:
     resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
-    dev: true
-
-  /tsup@6.7.0(typescript@5.0.4):
-    resolution: {integrity: sha512-L3o8hGkaHnu5TdJns+mCqFsDBo83bJ44rlK7e6VdanIvpea4ArPcU3swWGsLVbXak1PqQx/V+SSmFPujBK+zEQ==}
-    engines: {node: '>=14.18'}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': ^1
-      postcss: ^8.4.12
-      typescript: '>=4.1.0'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      postcss:
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      bundle-require: 4.0.1(esbuild@0.17.18)
-      cac: 6.7.14
-      chokidar: 3.5.3
-      debug: 4.3.4
-      esbuild: 0.17.18
-      execa: 5.1.1
-      globby: 11.1.0
-      joycon: 3.1.1
-      postcss-load-config: 3.1.4
-      resolve-from: 5.0.0
-      rollup: 3.21.3
-      source-map: 0.8.0-beta.0
-      sucrase: 3.32.0
-      tree-kill: 1.2.2
-      typescript: 5.0.4
-    transitivePeerDependencies:
-      - supports-color
-      - ts-node
     dev: true
 
   /tsutils@3.21.0(typescript@5.0.4):
@@ -3183,18 +2936,6 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /webidl-conversions@4.0.2:
-    resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
-    dev: true
-
-  /whatwg-url@7.1.0:
-    resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
-    dependencies:
-      lodash.sortby: 4.7.0
-      tr46: 1.0.1
-      webidl-conversions: 4.0.2
-    dev: true
-
   /which-boxed-primitive@1.0.2:
     resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}
     dependencies:
@@ -3241,11 +2982,6 @@ packages:
 
   /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
-    dev: true
-
-  /yaml@1.10.2:
-    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
-    engines: {node: '>= 6'}
     dev: true
 
   /yocto-queue@0.1.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,12 +96,12 @@ importers:
         specifier: 0.12.0-beta.3
         version: 0.12.0-beta.3
     devDependencies:
-      tsup:
-        specifier: ^6.7.0
-        version: 6.7.0(typescript@5.0.4)
       typescript:
         specifier: ~5.0.4
         version: 5.0.4
+      vite:
+        specifier: ^4.3.4
+        version: 4.3.4
 
   packages/gltf:
     dependencies:


### PR DESCRIPTION
Move package builds from tsup -> vite, which will allow us to use the thyseus rollup plugin.